### PR TITLE
fix typing imports for python 3.8

### DIFF
--- a/ties_merge.py
+++ b/ties_merge.py
@@ -9,7 +9,15 @@ import logging
 import os
 import os.path
 from dataclasses import dataclass
-from typing import Annotated, List, Literal, Optional
+from typing import List, Optional
+try:
+    from typing import Annotated
+except ImportError:
+    from typing_extensions import Annotated
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 import huggingface_hub
 import peft


### PR DESCRIPTION
Import Annotated and Literal from typing_extensions if unable to import from typing on Python 3.8